### PR TITLE
Add support for configuration file URL for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ FROM jboss/wildfly:10.1.0.Final
 #   TURN login. If not defined, a default value will NOT be provided
 # TURN_PASSWORD
 #   TURN password. If not defined, a default value will NOT be provided
+# CANDIDATE_TIMEOUT
+#   Timeout waiting for ICE candidates. If not defined a value of 0 is used, meaning no timeout
 #
 # Note, JBOSS will start on port 8080 by default only on the instance's IP
 #
@@ -46,6 +48,7 @@ FROM jboss/wildfly:10.1.0.Final
 USER root
 
 RUN yum -y update && yum clean all
+RUN yum install -y wget
 RUN echo $JBOSS_HOME
 RUN rm -rf $JBOSS_HOME/standalone/deployments/ROOT.war
 

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,4 +1,43 @@
 #!/bin/bash
+CONFFILE=/tmp/conf.sh
+
+download_file() {
+    if [ -n "$2" ]; then
+        wget "$1" --user="$2" --password="$3" -O $4
+    else
+        wget "$1" -O $2
+    fi
+    if [ $? -ne 0 ]; then
+        echo "Warning: environment configuration file failed to download; ignoring"
+        return 1
+    fi
+    return 0
+}
+
+function run_conf(){
+    echo "Sourcing configuration file $CONFFILE"
+    if [ -f $CONFFILE ]; then
+        chmod +x $CONFFILE
+        source $CONFFILE
+        rm -f $CONFFILE
+    else
+        echo "Warning: environment configuration file: $CONFFILE not found; ignoring"
+    fi
+}
+
+if [ -n "$ENVCONFURL" ]; then
+    # If the docker invocation provided $ENVCONFURL then the user wants to use the configuration
+    # hosted in the repository and hence overwrite current configuration with that
+    echo "Trying to download environment config from '$ENVCONFURL'"
+    if [[ -n "$REPOUSR" && -n "$REPOPWRD" ]]; then
+        download_file $ENVCONFURL $REPOUSR $REPOPWRD $CONFFILE
+        if [ $? -eq 0 ]; then
+            run_conf
+        fi
+    else
+        echo "Warning: Cannot download environment config from repository due to missing credentials; ignoring"
+    fi
+fi
 
 echo "Configuring Wildfly"
 python ./config-wildfly.py


### PR DESCRIPTION
It should be enabled by setting ENVCONFURL to the
URL of the configuration file, along with REPOUSR
and REPOPWRD with user and password for accessing.